### PR TITLE
Fix return type for resolver nameservers

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -8,7 +8,8 @@ from typing import (
     Any,
     List,
     Optional,
-    Set
+    Set,
+    Union
 )
 
 from . import error
@@ -58,7 +59,7 @@ class DNSResolver:
         self._timer = None  # type: Optional[asyncio.TimerHandle]
 
     @property
-    def nameservers(self) -> pycares.Channel:
+    def nameservers(self) -> List[Union[str, bytes]]:
         return self._channel.servers
 
     @nameservers.setter


### PR DESCRIPTION
The return type is incorrect, which leads to static typing errors